### PR TITLE
fixed colcon test action lint-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup ROS 2 Environment and Dependencies
         run: |
           source /opt/ros/humble/setup.bash
-          sudo rosdep init || true
+          [ -f /etc/ros/rosdep/sources.list.d/20-default.list ] || sudo rosdep init || true
           rosdep update
           rosdep install --from-paths src --ignore-src -r -y
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ if(BUILD_TESTING)
   set(ament_cmake_cpplint_FOUND TRUE)
 
   list(APPEND AMENT_LINT_AUTO_EXCLUDE
-    ament_cmake_uncrustify)
+    ament_cmake_uncrustify ament_cmake_lint_cmake)
 
   # enforce linters and static code analyzers defined in ament_lint_common package
   ament_lint_auto_find_test_dependencies()


### PR DESCRIPTION
1. excluded ament_cmake_lint_cmake from ament_lint_auto:
  - lint-check for CMakeLists.txt already executed in ci-step "Run ament_cmake_lint"
  - error stemmed from lint-checks inside build-folder 
2. included file check for rosdep init to suppress error